### PR TITLE
removes sensor id column when reading

### DIFF
--- a/R/scrape.R
+++ b/R/scrape.R
@@ -110,9 +110,10 @@ interp_time <- function(x) {
 }
 
 read_url <- function(url) {
-  utils::read.csv(
+  raw <- utils::read.csv(
     url, skip = 8, nrows = 63,
     colClasses = c("character", rep("integer", 24)),
     na.strings = "N/A", stringsAsFactors = FALSE, check.names = FALSE
   )
+  dplyr::select(raw, -`Sensor ID`)
 }


### PR DESCRIPTION
The csv format has been updated. This will fix the `melb_walk()` function so that it works with the new format.