### PR TITLE
Fix Date_Time name change

### DIFF
--- a/R/soda.R
+++ b/R/soda.R
@@ -99,9 +99,8 @@ melb_walk_fast <- function(year = NULL, sensor = NULL, na.rm = FALSE,
   ped <- dplyr::bind_rows(lst_dat)
   ped <- dplyr::mutate(
     ped,
-    Date_Time = as.POSIXct(strptime(date_time, format = "%Y-%m-%dT%H:%M:%S"),
-      tz = tz),
-    date_time = NULL,
+    Date_Time = as.POSIXct(strptime(Date_Time, format = "%Y-%m-%dT%H:%M:%S"),
+      tz = tz)
   )
   from_time <- as.POSIXct(paste0(min(year, na.rm = TRUE), "-01-01 00:00"),
       tz = tz)


### PR DESCRIPTION
Seems like the upstream data source now respects the query `"date_time AS Date_Time"`? I haven't tested much but was having issues which this change has fixed.